### PR TITLE
fix: the form-schema@1.0.0-alpha.5 package has case conflicts

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,8 +1,11 @@
+var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
+
 module.exports = {
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback.fs = false;
     }
+    config.plugins = [...config.plugins, new CaseSensitivePathsPlugin()];
     return config;
   },
 };

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "@button-inc/form-schema": "^1.0.0-alpha.5",
     "@rjsf/core": "^3.2.1",
     "@rjsf/semantic-ui": "^3.2.1",
+    "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "next": "latest",
     "next-session": "^3.4.0",
     "react": "^17.0.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1137,6 +1137,11 @@ caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.300012
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz#4a55f61c06abc9595965cfd77897dc7bc1cdc456"
   integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
 
+case-sensitive-paths-webpack-plugin@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz#db64066c6422eed2e08cc14b986ca43796dbc6d4"
+  integrity sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==
+
 chalk@2.4.2, chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
This PR ensures that developers on case-insensitive filesystems (looking at you, OSX) are warned when case conflict files are attempted to be loaded by webpack.