### PR TITLE
chore: enable debugger in dev mode

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "next",
+    "dev": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "start": "next start"
   },


### PR DESCRIPTION
This PR ensures that when the app is booted using `yarn dev` in the development environment that [the debugger is enabled](https://nodejs.org/en/docs/guides/debugging-getting-started/) by default. Without this change, the easiest way to trigger the debugger is by signalling the running node process, eg. via `kill -usr1 $(pgrep node)`