### PR TITLE
fix: github workflow metabase routes

### DIFF
--- a/.github/workflows/publish_deploy_image.yaml
+++ b/.github/workflows/publish_deploy_image.yaml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: Metabase-Test
-      url: "ccbc-metabase-dev.apps.silver.devops.gov.bc.ca"
+      url: "ccbc-metabase-test.apps.silver.devops.gov.bc.ca"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: Metabase-Production
-      url: "ccbc-metabase-prod.apps.silver.devops.gov.bc.ca"
+      url: "ccbc-metabase.apps.silver.devops.gov.bc.ca"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/helm/metabase/templates/deployer/deployerRole.yaml
+++ b/helm/metabase/templates/deployer/deployerRole.yaml
@@ -213,5 +213,14 @@ rules:
       - update
       - patch
       - delete
-
+  - apiGroups:
+    - postgres-operator.crunchydata.com
+    resources:
+    - postgresclusters
+    verbs:
+    - get
+    - create
+    - update
+    - patch
+    - delete
 {{ end }}


### PR DESCRIPTION
Looks like this was missed since I had to manually deploy the initial test and prod metabase namespaces.